### PR TITLE
Test build without CLI explicitly installed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,11 @@ sudo: required
 branches:
   only:
     - master
-before_script:
-  - npm install -g @angular/cli
+cache:
+  directories:
+    - ./node_modules
+install:
+  - npm install
 script:
   - ng lint
 #  - ng test


### PR DESCRIPTION
Addresses inexplicably annoying (breaking) prompt about telemetry opt-in during npm install @angular/cli in travis build